### PR TITLE
Use dorny/paths-filter for reliable path-based deploy triggering

### DIFF
--- a/.github/workflows/deploy-releases.yml
+++ b/.github/workflows/deploy-releases.yml
@@ -2,8 +2,13 @@
 name: Deploy to releases.slint.dev
 
 on:
-  push:
-    paths: 'releases/**'
+  workflow_call:
+    inputs:
+      new_release:
+        description: "Is this a new release? True means Cloudflare redirects will be updated and Docs will be scraped"
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       new_release:

--- a/.github/workflows/deploy-slintpad.yml
+++ b/.github/workflows/deploy-slintpad.yml
@@ -2,8 +2,7 @@
 name: Deploy to slintpad.com
 
 on:
-  push:
-    paths: 'slintpad/**'
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -2,8 +2,7 @@
 name: Deploy to snapshots.slint.dev
 
 on:
-  push:
-    paths: 'snapshots/**'
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,43 @@
+
+name: CI
+
+on:
+  push:
+
+jobs:
+  files-changed:
+    runs-on: ubuntu-latest
+    outputs:
+      releases: ${{ steps.filter.outputs.releases }}
+      snapshots: ${{ steps.filter.outputs.snapshots }}
+      slintpad: ${{ steps.filter.outputs.slintpad }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            releases:
+              - 'releases/**'
+            snapshots:
+              - 'snapshots/**'
+            slintpad:
+              - 'slintpad/**'
+
+  deploy-releases:
+    needs: files-changed
+    if: needs.files-changed.outputs.releases == 'true'
+    uses: ./.github/workflows/deploy-releases.yml
+    secrets: inherit
+
+  deploy-snapshots:
+    needs: files-changed
+    if: needs.files-changed.outputs.snapshots == 'true'
+    uses: ./.github/workflows/deploy-snapshots.yml
+    secrets: inherit
+
+  deploy-slintpad:
+    needs: files-changed
+    if: needs.files-changed.outputs.slintpad == 'true'
+    uses: ./.github/workflows/deploy-slintpad.yml
+    secrets: inherit


### PR DESCRIPTION
Replace unreliable built-in `paths:` push filters with a single deploy.yaml entry-point workflow that uses dorny/paths-filter@v4 to detect changes, then conditionally calls each deploy workflow. Deploy workflows now use workflow_call instead of push triggers, keeping workflow_dispatch for manual runs.