### PR TITLE
Add Basic-auth /simple/ endpoint so tokens stay out of uv.lock

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -22,12 +22,36 @@ If their repo is public, the `[[index]]` block goes in
 `~/.config/uv/uv.toml` instead (where the token URL isn't committed); the
 `[tool.uv.sources]` mapping stays in `pyproject.toml`.
 
+Alternatively, the token can travel out of band via HTTP Basic auth against
+the credential-free `/simple/` endpoint — this is what keeps it out of
+`uv.lock`:
+
+```toml
+[[tool.uv.index]]
+name = "slint-private"
+url = "https://testing.slint.dev/simple/"
+explicit = true
+
+[tool.uv.sources]
+slint-testing = { index = "slint-private" }
+```
+
+```sh
+export UV_INDEX_SLINT_PRIVATE_USERNAME=__token__
+export UV_INDEX_SLINT_PRIVATE_PASSWORD=<TOKEN>
+```
+
 ## Design
 
-**Token in the URL path, not in a header.** Means `--index-url` is the
-whole story on the customer side — no `~/.netrc`, no env vars, no
-per-tool auth glue. The token is opaque (32 random bytes, base64url) so
-URL-leakage is no worse than a leaked secret anywhere else.
+**Two front doors onto the same tree.** The token can ride in the URL path
+(`/t/<TOK>/`) or in an HTTP Basic password against `/simple/`. The path form
+makes `--index-url` the whole story — no env vars, no per-tool auth glue —
+but uv bakes the resolved URL (token included) into `uv.lock`. The `/simple/`
+form keeps the configured URL token-free, so credentials supplied via
+`UV_INDEX_<NAME>_USERNAME/_PASSWORD` never reach the lockfile. The token is
+opaque either way (32 random bytes, base64url). Both routes share the same
+D1 lookup and the same committed `_protected/` tree; only where the token is
+read differs.
 
 **Wheels and PEP 503 listings live under `assets/_protected/`**,
 committed to git, bundled into each Worker deploy. Nothing to
@@ -112,9 +136,12 @@ pnpm exec wrangler d1 execute ui-testing --local --command \
 
 ### How it behaves
 
-The Worker returns 404 (not 401) for missing/revoked tokens — `uv`/pip
-handle 404 cleanly, and we don't reveal which tokens exist. Revocation
-takes effect on the next request (D1 is strongly consistent).
+For path tokens (`/t/<TOK>/`) the Worker returns 404 (not 401) for
+missing/revoked tokens — `uv`/pip handle 404 cleanly, and we don't reveal
+which tokens exist. The Basic-auth route (`/simple/`) must answer 401 instead
+so `uv`/`curl` know to send or retry credentials; that response is uniform
+for missing and invalid tokens, so it still doesn't enumerate them.
+Revocation takes effect on the next request (D1 is strongly consistent).
 `last_used_at` is updated via `ctx.waitUntil(...)`, throttled to once
 per 60 s per token so the hot path stays cheap.
 
@@ -152,10 +179,12 @@ Ongoing:
 /                  →  assets/index.html                  (CDN, Worker not invoked)
 /t/<TOK>           →  301 /t/<TOK>/                      (so relative hrefs resolve)
 /t/<TOK>/<rest>    →  /_protected/<rest>                 (after validating <TOK> in D1)
+/simple/<rest>     →  /_protected/<rest>                 (after validating Basic-auth token in D1; 401 otherwise)
 /_protected/*      →  404                                (direct access blocked)
 ```
 
-`run_worker_first = ["/t/*", "/_protected/*"]` in `wrangler.toml` is
-what keeps the asset CDN from serving `_protected/` directly. The
-Worker also rewrites `Location` headers from asset-CDN 3xx responses so
-the internal `/_protected/` path never leaks.
+`run_worker_first = ["/t/*", "/simple/*", "/_protected/*"]` in
+`wrangler.toml` is what keeps the asset CDN from serving those paths
+directly. The Worker also rewrites `Location` headers from asset-CDN 3xx
+responses so the internal `/_protected/` path never leaks — for both the
+`/t/<TOK>/` and `/simple/` prefixes.

--- a/testing/src/index.ts
+++ b/testing/src/index.ts
@@ -25,6 +25,21 @@ export default {
 
     if (url.pathname.startsWith("/_protected/")) return notFound();
 
+    // Credential-gated mirror of the index. The token rides in the HTTP Basic
+    // password (username conventionally "__token__"), not the URL path, so it
+    // never lands in the customer's uv.lock. uv supplies it via
+    // UV_INDEX_<NAME>_USERNAME / _PASSWORD; the configured index URL is the
+    // token-free https://testing.slint.dev/simple/.
+    const sm = url.pathname.match(/^\/simple\/(.*)$/);
+    if (sm) {
+      const token = basicAuthToken(req.headers.get("authorization"));
+      if (!token) return needAuth();
+      const row = await lookupToken(env.DB, token);
+      if (!row) return needAuth();
+      touchTokenAsync(env.DB, row, ctx);
+      return serveProtected(env, req, url, sm[1], "/simple/");
+    }
+
     // /t/<TOK> → /t/<TOK>/ so relative hrefs in the served listing resolve
     // correctly against the customer-visible URL.
     if (/^\/t\/[^/]+$/.test(url.pathname)) {
@@ -41,31 +56,67 @@ export default {
     if (!row) return notFound();
     touchTokenAsync(env.DB, row, ctx);
 
-    const inner = new URL(url);
-    inner.pathname = `/_protected/${rest}`;
-    const r = await env.ASSETS.fetch(new Request(inner, req));
-
-    // The asset CDN may issue redirects (e.g. /_protected/foo → /_protected/foo/)
-    // whose Location would point at the internal namespace. Translate the
-    // path prefix back to the customer-visible one.
-    if (r.status >= 300 && r.status < 400 && r.headers.has("location")) {
-      const loc = r.headers.get("location")!;
-      const newLoc = loc.replace(
-        /(^|\/\/[^/]+)\/_protected\//,
-        `$1/t/${token}/`,
-      );
-      if (newLoc !== loc) {
-        const headers = new Headers(r.headers);
-        headers.set("location", newLoc);
-        return new Response(r.body, { status: r.status, headers });
-      }
-    }
-    return r;
+    return serveProtected(env, req, url, rest, `/t/${token}/`);
   },
 } satisfies ExportedHandler<Env>;
 
+// Serve assets/_protected/<rest>, rewriting any asset-CDN redirect Location
+// from the internal /_protected/ namespace back to the customer-visible prefix
+// (/t/<TOK>/ for path tokens, /simple/ for Basic auth).
+async function serveProtected(
+  env: Env,
+  req: Request,
+  url: URL,
+  rest: string,
+  prefix: string,
+): Promise<Response> {
+  const inner = new URL(url);
+  inner.pathname = `/_protected/${rest}`;
+  const r = await env.ASSETS.fetch(new Request(inner, req));
+
+  // The asset CDN may issue redirects (e.g. /_protected/foo → /_protected/foo/)
+  // whose Location would point at the internal namespace. Translate the
+  // path prefix back to the customer-visible one.
+  if (r.status >= 300 && r.status < 400 && r.headers.has("location")) {
+    const loc = r.headers.get("location")!;
+    const newLoc = loc.replace(/(^|\/\/[^/]+)\/_protected\//, `$1${prefix}`);
+    if (newLoc !== loc) {
+      const headers = new Headers(r.headers);
+      headers.set("location", newLoc);
+      return new Response(r.body, { status: r.status, headers });
+    }
+  }
+  return r;
+}
+
+// Extract the token from an HTTP Basic Authorization header. Accepts the token
+// as either the password (preferred, username = "__token__") or the username
+// (so `curl -u <token>:` works too).
+function basicAuthToken(header: string | null): string | null {
+  if (!header?.startsWith("Basic ")) return null;
+  let decoded: string;
+  try {
+    decoded = atob(header.slice("Basic ".length).trim());
+  } catch {
+    return null;
+  }
+  const [user, ...rest] = decoded.split(":");
+  return rest.join(":") || user || null;
+}
+
 function notFound(): Response {
   return new Response("Not Found", { status: 404 });
+}
+
+// Unlike the path-token route (which 404s to avoid revealing token existence),
+// Basic auth must answer 401 so uv/curl know to send or retry credentials. The
+// response is uniform for missing and invalid tokens, so it still doesn't
+// enumerate which tokens exist.
+function needAuth(): Response {
+  return new Response("Unauthorized", {
+    status: 401,
+    headers: { "WWW-Authenticate": 'Basic realm="testing.slint.dev"' },
+  });
 }
 
 async function lookupToken(

--- a/testing/test/e2e/run.sh
+++ b/testing/test/e2e/run.sh
@@ -12,8 +12,12 @@ set -euo pipefail
 #   5. Resolve & install through the token-gated index via:
 #        - `uv pip install --index-url …`   (pip-compat smoke)
 #        - `uv add` against a project that declares the index in pyproject.toml
+#        - `uv add` against the credential-free /simple/ endpoint, token
+#          supplied via UV_INDEX_<NAME>_PASSWORD — and assert the token never
+#          lands in uv.lock.
 #   6. Run a Python smoke import that exercises the cross-package dependency.
-#   7. Negative cases: bad token; revoked token. Both must fail.
+#   7. Negative cases: bad token; missing Basic-auth credentials; revoked
+#      token. All must fail.
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 E2E_DIR="$REPO_ROOT/test/e2e"
@@ -140,37 +144,76 @@ grep -q "localhost:$PORT"          "$CONSUMER/uv.lock"
 grep -q "slint-testing-e2e-leaf"   "$CONSUMER/uv.lock"
 grep -q "slint-testing-e2e-trunk"  "$CONSUMER/uv.lock"
 
-# --- Negative: bad token ---
+# --- Path C: /simple/ + Basic-auth credentials (token kept out of uv.lock) ---
 
-echo "→ Negative: bad token"
-if uv pip install \
-    --python "$TMP_DIR/.venv-pip/bin/python" \
-    --reinstall --refresh \
-    --index-url "http://localhost:$PORT/t/not-a-real-token/" \
-    slint-testing-e2e-trunk \
-    >"$TMP_DIR/bad-token.log" 2>&1; then
-  echo "FAIL: install succeeded with bad token" >&2
-  cat "$TMP_DIR/bad-token.log" >&2
+echo "→ Path C: uv add via /simple/ (credentials in env, not the URL)"
+SIMPLE_URL="http://localhost:$PORT/simple/"
+CONSUMER_BASIC="$TMP_DIR/consumer-basic"
+mkdir -p "$CONSUMER_BASIC"
+cat >"$CONSUMER_BASIC/pyproject.toml" <<EOF
+[project]
+name = "consumer-basic"
+version = "0.0.0"
+requires-python = ">=3.9"
+dependencies = []
+
+[[tool.uv.index]]
+name = "slint-private"
+url = "$SIMPLE_URL"
+default = true
+EOF
+
+(
+  cd "$CONSUMER_BASIC"
+  # uv derives the credential env-var names from the index name:
+  # slint-private → SLINT_PRIVATE.
+  export UV_INDEX_SLINT_PRIVATE_USERNAME=__token__
+  export UV_INDEX_SLINT_PRIVATE_PASSWORD="$TOKEN"
+  uv add slint-testing-e2e-trunk --quiet
+  uv run python "$E2E_DIR/smoke.py"
+)
+
+grep -q "localhost:$PORT/simple"   "$CONSUMER_BASIC/uv.lock"
+grep -q "slint-testing-e2e-leaf"   "$CONSUMER_BASIC/uv.lock"
+grep -q "slint-testing-e2e-trunk"  "$CONSUMER_BASIC/uv.lock"
+# The whole point: the token must NOT have leaked into the lockfile.
+if grep -q "$TOKEN" "$CONSUMER_BASIC/uv.lock"; then
+  echo "FAIL: token leaked into uv.lock" >&2
+  grep -n "$TOKEN" "$CONSUMER_BASIC/uv.lock" >&2
   exit 1
 fi
 
-# --- Negative: revoked token ---
+# --- Negative cases: every install below must be rejected by the index ---
 
-echo "→ Negative: revoked token"
+# Run `uv pip install` against an index that should reject us; fail the suite
+# if it unexpectedly succeeds.
+assert_install_fails() {
+  local label="$1" index_url="$2" log="$3"
+  echo "→ Negative: $label"
+  if uv pip install \
+      --python "$TMP_DIR/.venv-pip/bin/python" \
+      --reinstall --refresh \
+      --index-url "$index_url" \
+      slint-testing-e2e-trunk \
+      >"$log" 2>&1; then
+    echo "FAIL: install succeeded ($label)" >&2
+    cat "$log" >&2
+    exit 1
+  fi
+}
+
+assert_install_fails "/simple/ without credentials" \
+  "$SIMPLE_URL" "$TMP_DIR/no-creds.log"
+
+assert_install_fails "bad token" \
+  "http://localhost:$PORT/t/not-a-real-token/" "$TMP_DIR/bad-token.log"
+
+# Revoke the good token first, then confirm it stops working.
 pnpm exec wrangler d1 execute ui-testing --local --command \
   "UPDATE tokens SET revoked_at = unixepoch() WHERE token = '$TOKEN';" \
   >>"$WLOG" 2>&1
-
-if uv pip install \
-    --python "$TMP_DIR/.venv-pip/bin/python" \
-    --reinstall --refresh \
-    --index-url "$INDEX_URL" \
-    slint-testing-e2e-trunk \
-    >"$TMP_DIR/revoked-token.log" 2>&1; then
-  echo "FAIL: install succeeded with revoked token" >&2
-  cat "$TMP_DIR/revoked-token.log" >&2
-  exit 1
-fi
+assert_install_fails "revoked token" \
+  "$INDEX_URL" "$TMP_DIR/revoked-token.log"
 
 echo
 echo "✓ e2e passed"

--- a/testing/test/worker.test.ts
+++ b/testing/test/worker.test.ts
@@ -117,6 +117,99 @@ describe("token gating", () => {
   });
 });
 
+describe("basic-auth gating (/simple/)", () => {
+  const basic = (user: string, pass: string): Record<string, string> => ({
+    authorization: `Basic ${btoa(`${user}:${pass}`)}`,
+  });
+
+  it("returns 401 with no Authorization header", async () => {
+    await issueToken("ACME", "tok1");
+    const r = await SELF.fetch("https://example.com/simple/");
+    expect(r.status).toBe(401);
+    expect(r.headers.get("www-authenticate")).toMatch(/^Basic /);
+  });
+
+  it("returns 401 for an unknown token", async () => {
+    const r = await SELF.fetch("https://example.com/simple/", {
+      headers: basic("__token__", "nope"),
+    });
+    expect(r.status).toBe(401);
+  });
+
+  it("returns 401 for a revoked token", async () => {
+    await issueToken("ACME", "tok1");
+    await revokeToken("tok1");
+    const r = await SELF.fetch("https://example.com/simple/", {
+      headers: basic("__token__", "tok1"),
+    });
+    expect(r.status).toBe(401);
+  });
+
+  it("serves the root listing with the token as the password", async () => {
+    await issueToken("ACME", "tok1");
+    const r = await SELF.fetch("https://example.com/simple/", {
+      headers: basic("__token__", "tok1"),
+    });
+    expect(r.status).toBe(200);
+    expect(await r.text()).toContain("Simple Package Repository");
+  });
+
+  it("serves project listings with a valid token", async () => {
+    await issueToken("ACME", "tok1");
+    const r = await SELF.fetch("https://example.com/simple/foo/", {
+      headers: basic("__token__", "tok1"),
+    });
+    expect(r.status).toBe(200);
+    expect(await r.text()).toContain("Links for foo");
+  });
+
+  it("serves package files with a valid token", async () => {
+    await issueToken("ACME", "tok1");
+    const r = await SELF.fetch("https://example.com/simple/foo/foo-1.0.whl", {
+      headers: basic("__token__", "tok1"),
+    });
+    expect(r.status).toBe(200);
+    expect((await r.text()).trim()).toBe("fake-wheel-bytes");
+  });
+
+  it("accepts the token as the username too (curl -u <token>:)", async () => {
+    await issueToken("ACME", "tok1");
+    const r = await SELF.fetch("https://example.com/simple/", {
+      headers: basic("tok1", ""),
+    });
+    expect(r.status).toBe(200);
+    expect(await r.text()).toContain("Simple Package Repository");
+  });
+
+  it("rewrites asset-CDN redirect Location to the /simple/ prefix", async () => {
+    await issueToken("ACME", "tok1");
+    const r = await SELF.fetch("https://example.com/simple/foo", {
+      headers: basic("__token__", "tok1"),
+      redirect: "manual",
+    });
+    expect(r.status).toBeGreaterThanOrEqual(200);
+    if (r.status >= 300 && r.status < 400) {
+      const loc = r.headers.get("location") ?? "";
+      expect(loc).not.toContain("/_protected/");
+      expect(loc).toMatch(/\/simple\/foo\/?$/);
+    }
+  });
+
+  it("updates last_used_at on a valid request", async () => {
+    await issueToken("ACME", "tok1");
+    const r = await SELF.fetch("https://example.com/simple/", {
+      headers: basic("__token__", "tok1"),
+    });
+    expect(r.status).toBe(200);
+    const after = await env.DB.prepare(
+      "SELECT last_used_at FROM tokens WHERE token = ?",
+    )
+      .bind("tok1")
+      .first<{ last_used_at: number | null }>();
+    expect(after?.last_used_at).toBeTypeOf("number");
+  });
+});
+
 describe("protected namespace", () => {
   it("blocks direct access to /_protected/* paths", async () => {
     const r = await SELF.fetch("https://example.com/_protected/");

--- a/testing/wrangler.toml
+++ b/testing/wrangler.toml
@@ -12,7 +12,7 @@ binding = "ASSETS"
 # Worker runs first for these paths so it can validate tokens and block
 # direct access to _protected/. Anything else under assets/ (the public
 # landing page and its resources) is served directly by the asset CDN.
-run_worker_first = ["/t/*", "/_protected/*"]
+run_worker_first = ["/t/*", "/simple/*", "/_protected/*"]
 
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
The existing /t/<TOKEN>/ route embeds the token in the URL path, which uv bakes into the resolved package URLs in uv.lock. Add a parallel /simple/ endpoint that reads the token from an HTTP Basic password instead, so the configured index URL stays credential-free and uv (which never writes credentials to the lockfile) keeps the token out of it.

Both routes share the same D1 lookup and the same committed _protected/ tree via a factored-out serveProtected() helper; only token extraction and the missing/invalid response differ (404 for path tokens to avoid revealing existence, 401 for Basic auth so uv/curl send or retry credentials).

Covered by new unit tests and an e2e Path C that asserts the token never lands in uv.lock.