### PR TITLE
Add root llms.txt aggregator for docs.slint.dev

### DIFF
--- a/.github/workflows/deploy-releases.yml
+++ b/.github/workflows/deploy-releases.yml
@@ -92,6 +92,7 @@ jobs:
             rsync -ua ${{ steps.identify-version.outputs.VERSION }} docs
             cp versions.txt 404.html index.html docs
             cp ../robots-docs.txt docs/robots.txt
+            cp ../llms-docs.txt docs/llms.txt
             mv docs/${{ steps.identify-version.outputs.VERSION }} docs/latest
             find docs/latest -type f -exec sed -i "s@/${{ steps.identify-version.outputs.VERSION }}/docs@/latest/docs@g" {} \;
             find docs/latest -type f -exec sed -i "s@releases.slint.dev/latest/docs@docs.slint.dev/latest/docs@g" {} \;

--- a/llms-docs.txt
+++ b/llms-docs.txt
@@ -5,6 +5,7 @@
 > llms.txt (curated index) and llms-full.txt (full text).
 
 - [Slint language](https://docs.slint.dev/latest/docs/slint/llms.txt): the .slint language, built-in elements, widgets, and tutorials ([full text](https://docs.slint.dev/latest/docs/slint/llms-full.txt))
+- [Rust API](https://docs.slint.dev/latest/docs/rust/llms.txt): the native Rust API ([full text](https://docs.slint.dev/latest/docs/rust/llms-full.txt))
 - [C++ API](https://docs.slint.dev/latest/docs/cpp/llms.txt)
 - [JavaScript / TypeScript API](https://docs.slint.dev/latest/docs/node/llms.txt)
 - [Python API](https://docs.slint.dev/latest/docs/python/llms.txt)

--- a/llms-docs.txt
+++ b/llms-docs.txt
@@ -1,0 +1,14 @@
+# Slint Documentation
+
+> Machine-readable documentation index for Slint, a declarative GUI toolkit for
+> Rust, C++, JavaScript/TypeScript, and Python. Each language has its own
+> llms.txt (curated index) and llms-full.txt (full text).
+
+- [Slint language](https://docs.slint.dev/latest/docs/slint/llms.txt): the .slint language, built-in elements, widgets, and tutorials ([full text](https://docs.slint.dev/latest/docs/slint/llms-full.txt))
+- [C++ API](https://docs.slint.dev/latest/docs/cpp/llms.txt)
+- [JavaScript / TypeScript API](https://docs.slint.dev/latest/docs/node/llms.txt)
+- [Python API](https://docs.slint.dev/latest/docs/python/llms.txt)
+
+## Also
+- [Slint website](https://slint.dev/llms.txt)
+- [Slint on GitHub](https://github.com/slint-ui/slint)


### PR DESCRIPTION
## What

Adds a top-level **`https://docs.slint.dev/llms.txt`** — a small aggregator that links the per-language `llms.txt` indexes (Slint language, **Rust**, C++, JS/TS, Python).

## Why

The per-language `llms.txt` / `llms-full.txt` files land via [slint-ui/slint#12094](https://github.com/slint-ui/slint/pull/12094) (the `starlight-llms-txt` plugin on each docs site, plus a converter for the Rust rustdoc API). But there is no single root entry point: `https://docs.slint.dev/llms.txt` currently falls through to the catch-all redirect → `releases.slint.dev/llms.txt` → **404**. LLM crawlers and agent tools probe the apex `/llms.txt` first, so this gives them a real **200** index.

## How

Identical to how `robots-docs.txt` is already served as `/robots.txt`:

- New root file **`llms-docs.txt`** (the aggregator content).
- One line in `deploy-releases.yml`'s *"Copy latest release to docs"* step:

  ```diff
             cp ../robots-docs.txt docs/robots.txt
  +          cp ../llms-docs.txt docs/llms.txt
             mv docs/${{ steps.identify-version.outputs.VERSION }} docs/latest
  ```

The file is copied to the Cloudflare `docs` Pages root **before** the `mv … docs/latest` and the per-version → `/latest/` rewrites, so it stays at the apex and is served **before** the catch-all redirect fires — exactly like `robots.txt`. The apex is the Cloudflare **latest** host, so the `/latest/docs/...` links in the aggregator resolve correctly here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
